### PR TITLE
Renombrar columna de IVA en cálculos y exportación

### DIFF
--- a/data_processor.py
+++ b/data_processor.py
@@ -227,8 +227,8 @@ def calcular(
     )
 
     # Calcular IVA y precio final
-    df_calc['VALUE_ADDED_TAX'] = subtotal * 0.21
-    df_calc['Precio final'] = subtotal + df_calc['VALUE_ADDED_TAX']
+    df_calc['IVA'] = subtotal * 0.21
+    df_calc['Precio final'] = subtotal + df_calc['IVA']
 
     # Redondear a 2 decimales
     numeric_cols = [
@@ -238,7 +238,7 @@ def calcular(
         'Recargo fijo ML ($)',
         'Recargo financiación (importe)',
         'Recargo envío ($)',
-        'VALUE_ADDED_TAX',
+        'IVA',
         'Precio final'
     ]
     for col in numeric_cols:
@@ -282,7 +282,7 @@ def preparar_resultado_final(
     # Columnas comunes de resultados
     columnas_finales.extend([
         'Precio final',
-        'VALUE_ADDED_TAX',
+        'IVA',
         'Recargo % ML (importe)',
         'Recargo fijo ML ($)',
         'Recargo financiación (importe)'
@@ -317,7 +317,7 @@ def preparar_resultado_final(
         df_resultado['Tarifa + impuestos'] = df_calc['Tarifa + impuestos']
 
     df_resultado['Precio final'] = df_calc['Precio final']
-    df_resultado['VALUE_ADDED_TAX'] = df_calc['VALUE_ADDED_TAX']
+    df_resultado['IVA'] = df_calc['IVA']
     df_resultado['Recargo % ML (importe)'] = df_calc['Recargo % ML (importe)']
     df_resultado['Recargo fijo ML ($)'] = df_calc['Recargo fijo ML ($)']
     df_resultado['Recargo financiación (importe)'] = df_calc['Recargo financiación (importe)']

--- a/test_example.py
+++ b/test_example.py
@@ -1,6 +1,7 @@
 import pandas as pd
 import io
 from math import isclose
+from openpyxl import load_workbook
 from data_processor import leer_ml, leer_odoo, unir_y_validar, calcular, preparar_resultado_final, exportar_excel
 
 def crear_datos_ejemplo():
@@ -102,15 +103,15 @@ def test_procesamiento():
             print(f"  - {row['SKU']}: {row['TITLE'][:50]}...")
     print("\n💰 Calculando precios (base: tarifa, sin impuestos)...")
     df_calculated = calcular(df_merged, base_financiacion='tarifa', incluir_impuestos=False)
-    assert 'VALUE_ADDED_TAX' in df_calculated.columns
+    assert 'IVA' in df_calculated.columns
     producto_led = df_calculated[df_calculated['SKU'] == 'LED7012795'].iloc[0]
-    assert isclose(producto_led['VALUE_ADDED_TAX'], 4833.68, rel_tol=1e-04)
+    assert isclose(producto_led['IVA'], 4833.68, rel_tol=1e-04)
     assert isclose(producto_led['Precio final'], 27851.17, rel_tol=1e-04)
     print("\n📋 Preparando resultado final...")
     df_resultado = preparar_resultado_final(df_calculated, incluir_impuestos=False)
-    assert 'VALUE_ADDED_TAX' in df_resultado.columns
+    assert 'IVA' in df_resultado.columns
     resultado_led = df_resultado[df_resultado['SKU'] == 'LED7012795'].iloc[0]
-    assert isclose(resultado_led['VALUE_ADDED_TAX'], 4833.68, rel_tol=1e-04)
+    assert isclose(resultado_led['IVA'], 4833.68, rel_tol=1e-04)
     assert isclose(resultado_led['Precio final'], 27851.17, rel_tol=1e-04)
     print("✅ Procesamiento completado")
     print("\n📊 RESULTADOS DETALLADOS:")
@@ -135,14 +136,14 @@ def test_procesamiento():
     print("🧪 PRUEBA CON IMPUESTOS INCLUIDOS")
     print("=" * 50)
     df_calculated_tax = calcular(df_merged, base_financiacion='tarifa', incluir_impuestos=True)
-    assert 'VALUE_ADDED_TAX' in df_calculated_tax.columns
+    assert 'IVA' in df_calculated_tax.columns
     producto_led_tax = df_calculated_tax[df_calculated_tax['SKU'] == 'LED7012795'].iloc[0]
-    assert isclose(producto_led_tax['VALUE_ADDED_TAX'], 5800.46, rel_tol=1e-04)
+    assert isclose(producto_led_tax['IVA'], 5800.46, rel_tol=1e-04)
     assert isclose(producto_led_tax['Precio final'], 33421.68, rel_tol=1e-04)
     df_resultado_tax = preparar_resultado_final(df_calculated_tax, incluir_impuestos=True)
-    assert 'VALUE_ADDED_TAX' in df_resultado_tax.columns
+    assert 'IVA' in df_resultado_tax.columns
     resultado_led_tax = df_resultado_tax[df_resultado_tax['SKU'] == 'LED7012795'].iloc[0]
-    assert isclose(resultado_led_tax['VALUE_ADDED_TAX'], 5800.46, rel_tol=1e-04)
+    assert isclose(resultado_led_tax['IVA'], 5800.46, rel_tol=1e-04)
     assert isclose(resultado_led_tax['Precio final'], 33421.68, rel_tol=1e-04)
     print("\n📊 Comparación con y sin impuestos (primeros 3 items):")
     comparacion_cols = ['SKU', 'Precio de Tarifa', 'Tarifa + impuestos', 'Precio final']
@@ -158,6 +159,10 @@ def test_procesamiento():
     excel_bytes = exportar_excel(df_resultado)
     with open('ML_precios_y_stock_calculados_EJEMPLO.xlsx', 'wb') as f:
         f.write(excel_bytes)
+    wb = load_workbook(filename=io.BytesIO(excel_bytes))
+    ws = wb.active
+    headers = [cell.value for cell in next(ws.iter_rows(min_row=1, max_row=1))]
+    assert 'IVA' in headers
     print("✅ Archivo generado: ML_precios_y_stock_calculados_EJEMPLO.xlsx")
     print(f"\n📈 RESUMEN ESTADÍSTICO:")
     print("=" * 30)


### PR DESCRIPTION
## Summary
- renombrar la columna VALUE_ADDED_TAX a IVA en el cálculo de resultados y en la preparación del DataFrame final
- actualizar las pruebas para usar la nueva etiqueta y verificar que la exportación a Excel incluya el encabezado IVA

## Testing
- pytest *(falla: ModuleNotFoundError: No module named 'pandas' debido a que no fue posible instalar dependencias en el entorno)*

------
https://chatgpt.com/codex/tasks/task_e_68cc33288218832799d404263b75af33